### PR TITLE
Fixes #16 by checking the project directory to be created.

### DIFF
--- a/modules/chassis_openssl/manifests/init.pp
+++ b/modules/chassis_openssl/manifests/init.pp
@@ -2,7 +2,7 @@
 class chassis_openssl (
 	$config,
 ) {
-	if ( ! defined( File["/etc/nginx/sites-available/${name}.d"] ) ) {
+	if ( ! defined( File["/etc/nginx/sites-available/${::fqdn}.d"] ) ) {
 		file { "/etc/nginx/sites-available/${::fqdn}.d":
 			ensure  => directory,
 			require => Package['nginx']


### PR DESCRIPTION
Fixes #16 by implementing the patch.

The directory based on the fully qualified domain name doesn't always match the name, this results in the correct directory being declared multiple times when this extension is used in combination with other extensions that have the same check ([XFGUI](https://github.com/Chassis/Chassis_XHGui/blob/master/modules/chassis_xhgui/manifests/init.pp#L82)). 